### PR TITLE
Add JsonSchema support

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Feature | Java Library | Python Library | Notes
 :------ | :----------- | :------------- | :----
 Serialization and deserialization using schema registry | ✔️ | ✔️
 Avro message format | ✔️ | ✔️
-JSON Schema message format | ✔️ | ❌
+JSON Schema message format | ✔️ | ✔️
 Kafka Streams support | ✔️ | | N/A for Python, Kafka Streams is Java-only
 Compression | ✔️ | ✔️ |
 Local schema cache | ✔️ | ✔️

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = aws-glue-schema-registry
-version = 1.0.0
+version = 1.1.0
 description = Use the AWS Glue Schema Registry.
 long_description = file: README.md
 long_description_content_type = text/markdown
@@ -34,6 +34,8 @@ install_requires =
     boto3>=1.18.48
     typing-extensions>=3.10.0.2;python_version<"3.8"
     fastavro>=1.4.5
+    orjson~=3.6.0
+    fastjsonschema~=2.15
 setup_requires =
     setuptools
 
@@ -51,4 +53,7 @@ files = src,tests
 ignore_missing_imports = True
 
 [mypy-boto3.*]
+ignore_missing_imports = True
+
+[mypy-fastjsonschema.*]
 ignore_missing_imports = True

--- a/src/aws_schema_registry/jsonschema.py
+++ b/src/aws_schema_registry/jsonschema.py
@@ -45,9 +45,12 @@ class JsonSchema(Schema):
         return ""
 
     def read(self, bytes_: bytes):
-        return orjson.loads(bytes_)
+        data = orjson.loads(bytes_)
+        self.validate(data)
+        return data
 
     def write(self, data) -> bytes:
+        self.validate(data)
         return orjson.dumps(data)
 
     def validate(self, data):

--- a/src/aws_schema_registry/jsonschema.py
+++ b/src/aws_schema_registry/jsonschema.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from typing import Union
+
+import orjson
+
+import fastjsonschema
+
+from aws_schema_registry.schema import DataFormat, Schema, ValidationError
+
+
+class JsonSchema(Schema):
+    """Implementation of the `Schema` protocol for JSON schemas.
+
+    Arguments:
+        definition: the schema, either as a parsed dict or a string
+    """
+
+    def __init__(self, definition: Union[str, dict]):
+        if isinstance(definition, str):
+            self._dict = orjson.loads(definition)
+        else:
+            self._dict = definition
+        self._compiled_validation_method = fastjsonschema.compile(self._dict)
+
+    def __hash__(self):
+        return hash(str(self))
+
+    def __eq__(self, other):
+        return isinstance(other, JsonSchema) and \
+               self._dict == other._dict
+
+    def __str__(self):
+        return orjson.dumps(self._dict).decode()
+
+    def __repr__(self):
+        return '<JsonSchema %s>' % self._dict
+
+    @property
+    def data_format(self) -> DataFormat:
+        return 'JSON'
+
+    @property
+    def fqn(self) -> str:
+        return ""
+
+    def read(self, bytes_: bytes):
+        return orjson.loads(bytes_)
+
+    def write(self, data) -> bytes:
+        return orjson.dumps(data)
+
+    def validate(self, data):
+        try:
+            self._compiled_validation_method(data)
+        except fastjsonschema.exceptions.JsonSchemaValueException as e:
+            raise ValidationError(str(e)) from e

--- a/src/aws_schema_registry/serde.py
+++ b/src/aws_schema_registry/serde.py
@@ -6,6 +6,7 @@ from typing import Any, NamedTuple
 from uuid import UUID
 
 from aws_schema_registry.avro import AvroSchema
+from aws_schema_registry.jsonschema import JsonSchema
 from aws_schema_registry.client import SchemaRegistryClient
 from aws_schema_registry.codec import decode, encode, UnknownEncodingException
 from aws_schema_registry.exception import SchemaRegistryException
@@ -61,7 +62,7 @@ class KafkaSerializer:
         if data_and_schema is None:
             return None
         if not isinstance(data_and_schema, tuple):
-            raise TypeError('AvroSerializer can only serialize',
+            raise TypeError('KafkaSerializer can only serialize',
                             f' {tuple}, got {type(data_and_schema)}')
         data, schema = data_and_schema
         schema_version = self._get_schema_version(topic, schema)
@@ -136,4 +137,4 @@ class KafkaDeserializer:
         if version.data_format == 'AVRO':
             return AvroSchema(version.definition)
         elif version.data_format == 'JSON':
-            raise NotImplementedError('JSON schema not supported')
+            return JsonSchema(version.definition)

--- a/tests/integration/java/test_java_integration.py
+++ b/tests/integration/java/test_java_integration.py
@@ -32,9 +32,12 @@ def _topic_name_schema_type_name_strategy(topic, is_key, schema):
 
 
 @pytest.mark.parametrize("schema", [SCHEMA, JSON_SCHEMA])
-def test_interop_with_java_library(glue_client, registry, boto_session, schema):
+def test_interop_with_java_library(glue_client, registry,
+                                   boto_session, schema):
     client = SchemaRegistryClient(glue_client, registry_name=registry)
-    serializer = KafkaSerializer(client, schema_naming_strategy=_topic_name_schema_type_name_strategy)
+    serializer = KafkaSerializer(
+        client,
+        schema_naming_strategy=_topic_name_schema_type_name_strategy)
     deserializer = KafkaDeserializer(client)
 
     data = {
@@ -62,7 +65,8 @@ def test_interop_with_java_library(glue_client, registry, boto_session, schema):
             'AWS_SESSION_TOKEN': credentials.token,
             'AWS_REGION': boto_session.region_name,
             'REGISTRY_NAME': registry,
-            'SCHEMA_NAME': _topic_name_schema_type_name_strategy("test", False, schema)
+            'SCHEMA_NAME': _topic_name_schema_type_name_strategy(
+                "test", False, schema)
         }
     )
     print(proc.stderr)

--- a/tests/integration/java/user.json
+++ b/tests/integration/java/user.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "properties": {
+    "name": {
+      "type": "string"
+    },
+    "favorite_number": {
+      "type": "integer"
+    },
+    "favorite_color": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "name",
+    "favorite_number",
+    "favorite_color"
+  ]
+}

--- a/tests/integration/kafka/user.json
+++ b/tests/integration/kafka/user.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "properties": {
+    "name": {
+      "type": "string"
+    },
+    "favorite_number": {
+      "type": "integer"
+    },
+    "favorite_colors": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    }
+  },
+  "required": [
+    "name",
+    "favorite_number",
+    "favorite_colors"
+  ]
+}

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -10,9 +10,27 @@ from aws_schema_registry.exception import SchemaRegistryException
 
 REGISTRY_NAME = 'user-topic'
 SCHEMA_NAME = 'User-Topic'
+JSON_SCHEMA_NAME = 'User-Topic'
 SCHEMA_ARN = f'arn:aws:glue:us-west-2:123:schema/{REGISTRY_NAME}/{SCHEMA_NAME}'
 SCHEMA_VERSION_ID = UUID('b7b4a7f0-9c96-4e4a-a687-fb5de9ef0c63')
+JSON_SCHEMA_VERSION_ID = UUID('98718bb6-ca2a-4ac6-b841-748cab68b1b1')
 SCHEMA_DEF = '{"name": "Test", "type": "record", "fields": []}'
+JSON_SCHEMA_DEF = """{
+      "$schema": "http://json-schema.org/draft-04/schema#",
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "age": {
+          "type": "integer"
+        }
+      },
+      "required": [
+        "name",
+        "age"
+      ]
+    }"""
 
 METADATA = {
     'event-source-1': 'topic1',
@@ -97,6 +115,23 @@ def test_get_or_register_schema_version_creates_schema(client, glue_client):
 
     assert version.version_id == SCHEMA_VERSION_ID
 
+    glue_client.get_schema_version = Mock(return_value={
+        'SchemaVersionId': str(SCHEMA_VERSION_ID),
+        'SchemaDefinition': SCHEMA_DEF,
+        'DataFormat': 'JSON',
+        'SchemaArn': SCHEMA_ARN,
+        'VersionNumber': 123,
+        'Status': 'AVAILABLE'
+    })
+
+    version = client.get_or_register_schema_version(
+        definition=SCHEMA_DEF,
+        schema_name=SCHEMA_NAME,
+        data_format='JSON'
+    )
+
+    assert version.version_id == SCHEMA_VERSION_ID
+
 
 def test_get_or_register_schema_version_registers_version(
     client, glue_client
@@ -128,16 +163,22 @@ def test_get_or_register_schema_version_registers_version(
     assert version.version_id == SCHEMA_VERSION_ID
 
 
-def test_register_schema_version(client, glue_client):
+@pytest.mark.parametrize(
+    "schema_def,schema_name,schema_ver_id",
+    [(SCHEMA_DEF, SCHEMA_NAME, SCHEMA_VERSION_ID),
+     (JSON_SCHEMA_DEF, JSON_SCHEMA_NAME, JSON_SCHEMA_VERSION_ID)])
+def test_register_schema_version(client, glue_client,
+                                 schema_name, schema_def, schema_ver_id):
+    print(schema_name, schema_def, schema_ver_id)
     glue_client.register_schema_version = Mock(return_value={
-        'SchemaVersionId': str(SCHEMA_VERSION_ID),
+        'SchemaVersionId': str(schema_ver_id),
         'VersionNumber': 1,
         'Status': 'AVAILABLE'
     })
 
-    version_id = client.register_schema_version(SCHEMA_DEF, SCHEMA_NAME)
+    version_id = client.register_schema_version(schema_def, schema_name)
 
-    assert version_id == SCHEMA_VERSION_ID
+    assert version_id == schema_ver_id
 
 
 def test_wait_for_schema_evolution_check_to_complete(client, glue_client):
@@ -200,16 +241,17 @@ def _make_put_schema_version_metadata_response(
     }
 
 
-def test_create_schema(client, glue_client):
+@pytest.mark.parametrize("data_format", ["AVRO", "JSON"])
+def test_create_schema(client, glue_client, data_format):
     schema_version_id = uuid4()
     glue_client.create_schema = Mock(return_value={
         'SchemaName': SCHEMA_NAME,
-        'DataFormat': 'AVRO',
+        'DataFormat': data_format,
         'SchemaVersionId': str(schema_version_id)
     })
 
     version_id = client.create_schema(
-        SCHEMA_NAME, 'AVRO', SCHEMA_DEF
+        SCHEMA_NAME, data_format, SCHEMA_DEF
     )
 
     assert version_id == schema_version_id

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -10,7 +10,7 @@ from aws_schema_registry.exception import SchemaRegistryException
 
 REGISTRY_NAME = 'user-topic'
 SCHEMA_NAME = 'User-Topic'
-JSON_SCHEMA_NAME = 'User-Topic'
+JSON_SCHEMA_NAME = 'User-Topic-json'
 SCHEMA_ARN = f'arn:aws:glue:us-west-2:123:schema/{REGISTRY_NAME}/{SCHEMA_NAME}'
 SCHEMA_VERSION_ID = UUID('b7b4a7f0-9c96-4e4a-a687-fb5de9ef0c63')
 JSON_SCHEMA_VERSION_ID = UUID('98718bb6-ca2a-4ac6-b841-748cab68b1b1')

--- a/tests/test_jsonschema.py
+++ b/tests/test_jsonschema.py
@@ -31,6 +31,35 @@ def test_readwrite():
     assert s.read(s.write(d)) == d
 
 
+def test_validation_during_read_write():
+    s = JsonSchema("""{
+          "$schema": "http://json-schema.org/draft-04/schema#",
+          "type": "object",
+          "properties": {
+            "name": {
+              "type": "string"
+            },
+            "age": {
+              "type": "integer"
+            }
+          },
+          "required": [
+            "name",
+            "age"
+          ]
+        }""")
+
+    with pytest.raises(ValidationError, match=re.escape(
+        "data.name must be string"
+    )):
+        s.read(b'{"name": 1, "age": 2}')
+
+    with pytest.raises(ValidationError, match=re.escape(
+        "data.name must be string"
+    )):
+        s.write({"name": 1, "age": 2})
+
+
 def test_validation():
     s = JsonSchema("""{
       "$schema": "http://json-schema.org/draft-04/schema#",
@@ -52,12 +81,10 @@ def test_validation():
     with pytest.raises(ValidationError, match=re.escape(
         "data must contain ['name', 'age'] properties"
     )):
-
         s.validate({'name': 'Obi-Wan'})
     with pytest.raises(ValidationError, match=re.escape(
         "data.name must be string"
     )):
-
         s.validate({'name': 1, 'age': 2})
 
     s.validate({'name': 'Jar Jar', 'age': 42, 'sith': True})
@@ -83,5 +110,4 @@ def test_validation():
     with pytest.raises(ValidationError, match=re.escape(
         "data must not contain {'sith'} properties"
     )):
-
         s.validate({'name': 'Jar Jar', 'age': 42, 'sith': True})

--- a/tests/test_jsonschema.py
+++ b/tests/test_jsonschema.py
@@ -1,0 +1,87 @@
+import re
+import pytest
+
+from aws_schema_registry import ValidationError
+from aws_schema_registry.jsonschema import JsonSchema
+
+
+def test_readwrite():
+    s = JsonSchema("""{
+          "$schema": "http://json-schema.org/draft-04/schema#",
+          "type": "object",
+          "properties": {
+            "name": {
+              "type": "string"
+            },
+            "age": {
+              "type": "integer"
+            }
+          },
+          "required": [
+            "name",
+            "age"
+          ]
+        }""")
+
+    d = {
+        'name': 'Yoda',
+        'age': 900
+    }
+
+    assert s.read(s.write(d)) == d
+
+
+def test_validation():
+    s = JsonSchema("""{
+      "$schema": "http://json-schema.org/draft-04/schema#",
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "age": {
+          "type": "integer"
+        }
+      },
+      "required": [
+        "name",
+        "age"
+      ]
+    }""")
+
+    with pytest.raises(ValidationError, match=re.escape(
+        "data must contain ['name', 'age'] properties"
+    )):
+
+        s.validate({'name': 'Obi-Wan'})
+    with pytest.raises(ValidationError, match=re.escape(
+        "data.name must be string"
+    )):
+
+        s.validate({'name': 1, 'age': 2})
+
+    s.validate({'name': 'Jar Jar', 'age': 42, 'sith': True})
+
+    s = JsonSchema("""{
+          "$schema": "http://json-schema.org/draft-04/schema#",
+          "type": "object",
+          "properties": {
+            "name": {
+              "type": "string"
+            },
+            "age": {
+              "type": "integer"
+            }
+          },
+          "required": [
+            "name",
+            "age"
+          ],
+          "additionalProperties": false
+        }""")
+
+    with pytest.raises(ValidationError, match=re.escape(
+        "data must not contain {'sith'} properties"
+    )):
+
+        s.validate({'name': 'Jar Jar', 'age': 42, 'sith': True})


### PR DESCRIPTION
Following up on #5 
I added support for JsonSchema, 

- [x] Unittests pass
- [x] flake and mypy linting and type check pass
- [x] Kafka integration tests pass
- [x] Readme updated to include JSON schema support
- [x] Bumped version to 1.1.0
- [x] Java compatibility tests
 
~I wasn't able to test the java compatibility test. (Had some issues with the compilation, and either way, I wouldn't really know what to test since I'm not familiar with the java library)~

Please let me know if there is anything else that needs fixing.
Thanks again :) 👍 