### PR TITLE
Lower boto3 dependency version

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -31,7 +31,7 @@ package_dir =
     =src
 python_requires = >=3.7
 install_requires =
-    boto3>=1.18.48
+    boto3>=1.17.102
     typing-extensions>=3.10.0.2;python_version<"3.8"
     fastavro>=1.4.5
     orjson~=3.6.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = aws-glue-schema-registry
-version = 1.1.0
+version = 1.1.1
 description = Use the AWS Glue Schema Registry.
 long_description = file: README.md
 long_description_content_type = text/markdown


### PR DESCRIPTION
[aioboto](https://github.com/terrycain/aioboto3) (the asyncio version of boto3) requires that boto3 will be `1.17.106`, this pkg requires `>=1.18.48`, which means they cant be installed together (which also somewhat rules out work with aiokafka).

I lowerd the version to `1.17.102`, since according to the [changelog for boto3 ](https://github.com/boto/boto3/blob/develop/CHANGELOG.rst#117102) this is when JSON support for the glue schema was added, and there was no change between that and 1.18.48 that relates to this project.

- [x] Run all unit&integration tests with boto3==1.17.102 and they all passed
- [x] Bumped version to 1.1.1 