### PR TITLE
Lower typing-extensions dependency version

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = aws-glue-schema-registry
-version = 1.1.1
+version = 1.1.2
 description = Use the AWS Glue Schema Registry.
 long_description = file: README.md
 long_description_content_type = text/markdown
@@ -32,7 +32,7 @@ package_dir =
 python_requires = >=3.7
 install_requires =
     boto3>=1.17.102
-    typing-extensions>=3.10.0.2;python_version<"3.8"
+    typing-extensions>=3.7.4.3;python_version<"3.8"
     fastavro>=1.4.5
     orjson~=3.6.0
     fastjsonschema~=2.15


### PR DESCRIPTION
I lowered the typing-extensions dependency to 3.7.4.3 since we have a restriction by the AWS managed Airflow (MWWA). 
Unit tests have been successful.